### PR TITLE
[Version][Fix] New update fix register token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 # This lines below serve as a reference and need to be used on plugin.rb
 # https://meta.discourse.org/t/plugin-using-own-gem/50007/4
-gem "rake", "13.0.6"
-gem "connection_pool", "2.4.1"
-gem "unf_ext", "0.0.8.2"
-gem "unf", "0.1.4"
-gem "domain_name", "0.5.20190701"
-gem "http-cookie", "1.0.5"
-gem "ffi", "1.16.3"
-gem "llhttp-ffi", "0.4.0"
-gem "public_suffix", "5.0.0"
-gem "addressable", "2.8.1"
-gem "http-form_data", "2.3.0"
-gem "http", "5.1.0"
-gem "expo-server-sdk", "0.1.4"
+gem 'addressable', '2.8.1'
+gem 'connection_pool', '2.4.1'
+gem 'domain_name', '0.5.20190701'
+gem 'expo-server-sdk', '0.1.4'
+gem 'ffi', '1.16.3'
+gem 'http', '5.1.0'
+gem 'http-cookie', '1.0.5'
+gem 'http-form_data', '2.3.0'
+gem 'llhttp-ffi', '0.4.0'
+gem 'public_suffix', '5.0.4'
+gem 'rake', '13.1.0'
+gem 'unf', '0.1.4'
+gem 'unf_ext', '0.0.9.1'
 
 # This lines below are gems that are not needed for runtime
-gem "ruby-lsp", "~> 0.3.6"
+gem 'ruby-lsp', '~> 0.3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     prettier_print (1.1.0)
-    public_suffix (5.0.0)
-    rake (13.0.6)
+    public_suffix (5.0.4)
+    rake (13.1.0)
     ruby-lsp (0.3.6)
       language_server-protocol (~> 3.17.0)
       sorbet-runtime
@@ -37,7 +37,7 @@ GEM
       prettier_print (>= 1.0.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
 
 PLATFORMS
   arm64-darwin-21
@@ -53,11 +53,11 @@ DEPENDENCIES
   http-cookie (= 1.0.5)
   http-form_data (= 2.3.0)
   llhttp-ffi (= 0.4.0)
-  public_suffix (= 5.0.0)
-  rake (= 13.0.6)
+  public_suffix (= 5.0.4)
+  rake (= 13.1.0)
   ruby-lsp (~> 0.3.6)
   unf (= 0.1.4)
-  unf_ext (= 0.0.8.2)
+  unf_ext (= 0.0.9.1)
 
 BUNDLED WITH
    2.4.4

--- a/app/controllers/discourse_lexicon_plugin/expo_pn_controller.rb
+++ b/app/controllers/discourse_lexicon_plugin/expo_pn_controller.rb
@@ -17,7 +17,6 @@ module DiscourseLexiconPlugin
 
       ExpoPnSubscription
         .where(expo_pn_token: expo_pn_token)
-        .where.not(user_id: current_user.id)
         .destroy_all
 
       record =

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,14 +8,14 @@
 
 # We need to load all external packages first
 # Reference: https://meta.discourse.org/t/plugin-using-own-gem/50007/4
-gem 'rake', '13.0.6'
+gem 'rake', '13.1.0'
 gem 'connection_pool', '2.4.1'
-gem 'unf_ext', '0.0.8.2'
+gem 'unf_ext', '0.0.9.1'
 gem 'unf', '0.1.4'
 gem 'domain_name', '0.5.20190701'
 gem 'http-cookie', '1.0.5'
 gem 'ffi', '1.16.3'
-gem 'public_suffix', '5.0.3'
+gem 'public_suffix', '5.0.4'
 gem 'addressable', '2.8.5'
 gem 'ffi-compiler', '1.0.1', require_name: 'ffi-compiler/loader'
 gem 'llhttp-ffi', '0.4.0', require_name: 'llhttp'


### PR DESCRIPTION
# Type of PR

- [x] 🐞 Bug fix (_non-breaking change which fixes an issue_)
- [ ] 🧙‍♂️ New feature (_adding a feature following a feature-request issue_)
- [ ] 🔨 Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
- [ ] 🏗️ Refactor (_rewriting existing code without any feature change_)
- [ ] ✍️ (!) This change is or requires a documentation update

# Description

Fix Error DB `ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_expo_pn_subscriptions_on_expo_pn_token"
DETAIL:  Key (expo_pn_token)=(ExponentPushToken[OehktgBlr7yystf9R9sM_S]) already exists.
)`. 

This error occurs when attempting to log in and generate a new push notification after changing the experience ID. So, when we change the experience ID, log out of the app, and then log in again, it triggers a database (DB) error.

To address this issue, we can follow the guidance provided in [this comment](https://github.com/expo/expo/issues/1135#issuecomment-352988377). Expo push notifications are always unique between experiences, so our solution is to delete all instances of the same Expo token.

- Up version rake into 13.1.0
- Up version unf_ext into 0.0.9.1
- Up version public_suffix 5.0.4

### **Changes**

<details>
<summary>Date:Tue, 5 Dec 2023</summary>

#### **Contextual Changes:**

- Delete condition .where.not(user_id: current_user.id) in `app/controllers/discourse_lexicon_plugin/expo_pn_controller.rb`
- Up version rake into 13.1.0
- Up version unf_ext into 0.0.9.1
- Up version public_suffix 5.0.4

</details>

## **Additional Screenshots**


## Additional information/context

