### PR TITLE
[Package][Gemfile] remove dependencies which already install at discourse core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,4 @@
 source 'https://rubygems.org'
-# This lines below serve as a reference and need to be used on plugin.rb
-# https://meta.discourse.org/t/plugin-using-own-gem/50007/4
-gem 'addressable', '2.8.7'
-gem 'connection_pool', '2.4.1'
-gem 'domain_name', '0.5.20190701'
-gem 'expo-server-sdk', '0.1.4'
-gem 'ffi', '1.17.0'
-gem 'http', '5.1.0'
-gem 'http-cookie', '1.0.5'
-gem 'http-form_data', '2.3.0'
-gem 'llhttp-ffi', '0.4.0'
-gem 'public_suffix', '6.0.1'
-gem 'rake', '13.2.1'
-gem 'unf', '0.1.4'
-gem 'unf_ext', '0.0.9.1'
 
 # This lines below are gems that are not needed for runtime
 gem 'ruby-lsp', '~> 0.3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    connection_pool (2.4.1)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    expo-server-sdk (0.1.4)
-      connection_pool (~> 2.2)
-      http (>= 4.0, < 6.0)
-    ffi (1.17.0)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
-      rake
-    http (5.1.0)
-      addressable (~> 2.8)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.4.0)
-    http-cookie (1.0.5)
-      domain_name (~> 0.5)
-    http-form_data (2.3.0)
     language_server-protocol (3.17.0.2)
-    llhttp-ffi (0.4.0)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
     prettier_print (1.1.0)
-    public_suffix (6.0.1)
-    rake (13.2.1)
     ruby-lsp (0.3.6)
       language_server-protocol (~> 3.17.0)
       sorbet-runtime
@@ -35,29 +10,13 @@ GEM
     sorbet-runtime (0.5.10575)
     syntax_tree (4.3.0)
       prettier_print (>= 1.0.2)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.9.1)
 
 PLATFORMS
   arm64-darwin-21
   ruby
 
 DEPENDENCIES
-  addressable (= 2.8.7)
-  connection_pool (= 2.4.1)
-  domain_name (= 0.5.20190701)
-  expo-server-sdk (= 0.1.4)
-  ffi (= 1.17.0)
-  http (= 5.1.0)
-  http-cookie (= 1.0.5)
-  http-form_data (= 2.3.0)
-  llhttp-ffi (= 0.4.0)
-  public_suffix (= 6.0.1)
-  rake (= 13.2.1)
   ruby-lsp (~> 0.3.6)
-  unf (= 0.1.4)
-  unf_ext (= 0.0.9.1)
 
 BUNDLED WITH
    2.4.4

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,19 +8,15 @@
 
 # We need to load all external packages first
 # Reference: https://meta.discourse.org/t/plugin-using-own-gem/50007/4
-gem 'rake', '13.2.1'
-gem 'connection_pool', '2.4.1'
-gem 'unf_ext', '0.0.9.1'
-gem 'unf', '0.1.4'
+# After testing, we determined that we do not need to load all the dependent packages already installed in the Discourse core. However, `ffi` is required because we encountered the error: `Error installing llhttp-ffi Gem::MissingSpecError: Could not find 'ffi' (>= 1.15.5)`.
+
 gem 'domain_name', '0.5.20190701'
 gem 'http-cookie', '1.0.5'
 gem 'ffi', '1.17.0'
-gem 'public_suffix', '6.0.1'
-gem 'addressable', '2.8.7'
-gem 'ffi-compiler', '1.0.1', require_name: 'ffi-compiler/loader'
+gem 'ffi-compiler', '1.3.2', require_name: 'ffi-compiler/loader'
 gem 'llhttp-ffi', '0.4.0', require_name: 'llhttp'
 gem 'http-form_data', '2.3.0', require_name: 'http/form_data'
-gem 'http', '5.1.0'
+gem 'http', '5.1.1'
 require_relative 'lib/expo_server_sdk_ruby/expo/server/sdk'
 
 enabled_site_setting :lexicon_push_notifications_enabled


### PR DESCRIPTION
# Type of PR

- [ ] 🐞 Bug fix (_non-breaking change which fixes an issue_)
- [ ] 🧙‍♂️ New feature (_adding a feature following a feature-request issue_)
- [ ] 🔨 Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
- [ ] 🏗️ Refactor (_rewriting existing code without any feature change_)
- [ ] ✍️ (!) This change is or requires a documentation update

# Description

Based on the recommendations in this [topic](https://meta.discourse.org/t/installing-a-git-based-gem-from-a-discourse-plugin/238657), we decided to remove version specifications for dependencies in the Gemfile and add gem packages directly in plugin.rb for better compatibility.


Besides that, we removed some dependencies that are already installed in the Discourse core:

```ruby
gem 'connection_pool', '2.4.1'
gem 'unf_ext', '0.0.9.1'
gem 'unf', '0.1.4'
gem 'public_suffix', '6.0.1'
gem 'addressable', '2.8.7'
```

However, the `ffi` dependency is required by `llhttp-ffi`. If we remove this dependency, it throws the error: `Error installing llhttp-ffi Gem::MissingSpecError: Could not find 'ffi' (>= 1.15.5)`


## **Additional Screenshots**

Provide screenshot if necessary.

## Additional information/context

_If relevant, add any information or context that would be useful to evaluate this PR_
