### PR TITLE
Add static value for badge count notification

### DIFF
--- a/app/services/push_notification_manager.rb
+++ b/app/services/push_notification_manager.rb
@@ -16,6 +16,8 @@ class PushNotificationManager
                                                                 channel_name)
     title = content[:title]
     body = content[:body]
+    badge = 1 # temporary fixed badge count for iOS
+
 
     client = Expo::Push::Client.new
     experience_id_group = build_experience_id_groups(expo_pn_subscriptions)
@@ -37,6 +39,7 @@ class PushNotificationManager
                     .sound('default')
                     .title(title)
                     .body(body)
+                    .badge(badge)
                     .data(
                       {
                         'discourse_url' => post_url,


### PR DESCRIPTION
# Type of PR

- [ ] 🐞 Bug fix (_non-breaking change which fixes an issue_)
- [ ] 🧙‍♂️ New feature (_adding a feature following a feature-request issue_)
- [x] 🔨 Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
- [ ] 🏗️ Refactor (_rewriting existing code without any feature change_)
- [ ] ✍️ (!) This change is or requires a documentation update

# Description

Add static value of `1` as badge count on each notification to trigger badge notification

